### PR TITLE
デプロイ先で css が機能していないバグを修正

### DIFF
--- a/app/views/layouts/application.html.slim
+++ b/app/views/layouts/application.html.slim
@@ -5,7 +5,7 @@ html
     meta[name="viewport" content="width=device-width,initial-scale=1"]
     = csrf_meta_tags
     = csp_meta_tag
-    = stylesheet_link_tag 'application', media: 'all', 'data-turbolinks-track': 'reload'
+    = stylesheet_pack_tag 'application', media: 'all', 'data-turbolinks-track': 'reload'
     = javascript_pack_tag 'application', 'data-turbolinks-track': 'reload'
   body
     = yield


### PR DESCRIPTION
closes #41 

## 概要
ローカルでは css が適用されているのに、デプロイ先では css が適用されないというバグが発生した。
css の読み込みの方式を`stylesheet_link_tag`から`stylesheet_pack_tag`に変更することで対処できた。