### PR TITLE
ステージ選択画面から各ステージに遷移した際、画面が描写されないバグを解消

### DIFF
--- a/app/javascript/stage_panel_tile.js
+++ b/app/javascript/stage_panel_tile.js
@@ -1,7 +1,7 @@
 import { createApp } from 'vue'
 import StagePanelTile from './StagePanelTile.vue'
 
-document.addEventListener('DOMContentLoaded', () => {
+document.addEventListener('turbolinks:load', () => {
   const selector = '#js-stage-panel-tile'
   if (!document.querySelector(selector)) return
   createApp(StagePanelTile).mount(selector)

--- a/app/javascript/stage_play.js
+++ b/app/javascript/stage_play.js
@@ -1,7 +1,7 @@
 import { createApp } from 'vue'
 import StagePlay from './StagePlay.vue'
 
-document.addEventListener('DOMContentLoaded', () => {
+document.addEventListener('turbolinks:load', () => {
   const selector = '#js-stage-play'
   const stage = document.querySelector(selector)
   if (!stage) return

--- a/app/javascript/stage_select.js
+++ b/app/javascript/stage_select.js
@@ -1,7 +1,7 @@
 import { createApp } from 'vue'
 import StageSelect from './StageSelect.vue'
 
-document.addEventListener('DOMContentLoaded', () => {
+document.addEventListener('turbolinks:load', () => {
   const selector = '#js-stage-select'
   if (!document.querySelector(selector)) return
   createApp(StageSelect).mount(selector)

--- a/app/javascript/stage_select_header.js
+++ b/app/javascript/stage_select_header.js
@@ -1,7 +1,7 @@
 import { createApp } from 'vue'
 import StageSelectHeader from './StageSelectHeader.vue'
 
-document.addEventListener('DOMContentLoaded', () => {
+document.addEventListener('turbolinks:load', () => {
   const selector = '#js-stage-select-header'
   if (!document.querySelector(selector)) return
   createApp(StageSelectHeader).mount(selector)

--- a/app/javascript/stage_select_panel.js
+++ b/app/javascript/stage_select_panel.js
@@ -1,7 +1,7 @@
 import { createApp } from 'vue'
 import StageSelectPanel from './StageSelectPanel.vue'
 
-document.addEventListener('DOMContentLoaded', () => {
+document.addEventListener('turbolinks:load', () => {
   const selector = '#js-stage-select'
   if (!document.querySelector(selector)) return
   createApp(StageSelectPanel).mount(selector)


### PR DESCRIPTION
closes #50 

## 概要
バグの原因は、turbolinks のロードを待っていなかったことだった。
turbolinksのロード後にVueインスタンスが生成されるようにし、バグを解消した。