### PR TITLE
OGP用画像へのパスを修正

### DIFF
--- a/next-seo.config.ts
+++ b/next-seo.config.ts
@@ -8,7 +8,7 @@ export default {
     description: 'ゲームとゴロ合わせで円周率を覚えよう！',
     images: [
       {
-        url: 'https://gorogoropanda.com/ogp/ogp.png.',
+        url: 'https://gorogoropanda.com/ogp/ogp.png',
         width: 1200,
         height: 630,
         alt: 'Og Image Alt',


### PR DESCRIPTION
## 概要
OGP用画像へのパスの最後に、余計な`.`が付いてしまっていたのを削除した。