### PR TITLE
ローカルストレージでステージのアンロック状態を管理するようにした

### DIFF
--- a/src/components/StageDescription.tsx
+++ b/src/components/StageDescription.tsx
@@ -3,10 +3,21 @@ type Props = {
 };
 
 const StageDescription = ({ stageNumber }: Props) => {
-  const displayStage = (stageNumber: number): string => {
-    const circledNumbers = ['①', '②', '③', '④', '⑤', '⑥', '⑦', '⑧', '⑨', '⑩'];
+  const displayStage = (stageNumber: string): string => {
+    const circledNumbers: { [key: string]: string } = {
+      '1': '①',
+      '2': '②',
+      '3': '③',
+      '4': '④',
+      '5': '⑤',
+      '6': '⑥',
+      '7': '⑦',
+      '8': '⑧',
+      '9': '⑨',
+      '10': '⑩',
+    };
 
-    return `ステージ${circledNumbers[stageNumber - 1]}`;
+    return `ステージ${circledNumbers[stageNumber]}`;
   };
   const displayDigitsRange = (stageNumber: number): string => {
     const startDigit: number = 10 * (stageNumber - 1) + 1;
@@ -17,7 +28,7 @@ const StageDescription = ({ stageNumber }: Props) => {
 
   return (
     <h1 className="mt-1">
-      {displayStage(parseInt(stageNumber))}
+      {displayStage(stageNumber)}
       <span className="ml-4" />
       {displayDigitsRange(parseInt(stageNumber))}
     </h1>

--- a/src/components/StageSelectPanel.tsx
+++ b/src/components/StageSelectPanel.tsx
@@ -1,16 +1,20 @@
 import Link from 'next/link';
 
 import StageSelectPanelContent from './StageSelectPanelContent';
+import { useClearedStage } from '../hooks/useClearedStage';
 
 type Props = {
   panelNumber: string;
   stage: number;
-  isLocked: boolean;
 };
 
 export const stagePath = (stage: number): string => `/stages/${stage}`;
 
-function StageSelectPanel({ panelNumber, stage, isLocked }: Props) {
+function StageSelectPanel({ panelNumber, stage }: Props) {
+  const clearedStage = useClearedStage(0)[0];
+
+  const isLocked = stage > parseInt(clearedStage) + 1;
+
   const backGroundColor = (stage: number): string => {
     // Tailwindはクライアントサイドでのランタイムを考慮しないため、クラス名は静的である必要がある。
     const colors: string[] = [

--- a/src/components/StageSelectPanel.tsx
+++ b/src/components/StageSelectPanel.tsx
@@ -8,6 +8,24 @@ type Props = {
   stage: number;
 };
 
+export const backGroundColor = (stage: number): string => {
+  // Tailwindはクライアントサイドでのランタイムを考慮しないため、クラス名は静的である必要がある。
+  const colors: { [key: number]: string } = {
+    1: 'bg-stage-1',
+    2: 'bg-stage-2',
+    3: 'bg-stage-3',
+    4: 'bg-stage-4',
+    5: 'bg-stage-5',
+    6: 'bg-stage-6',
+    7: 'bg-stage-7',
+    8: 'bg-stage-8',
+    9: 'bg-stage-9',
+    10: 'bg-stage-10',
+  };
+
+  return colors[stage];
+};
+
 export const stagePath = (stage: number): string => `/stages/${stage}`;
 
 function StageSelectPanel({ panelNumber, stage }: Props) {
@@ -15,23 +33,6 @@ function StageSelectPanel({ panelNumber, stage }: Props) {
 
   const isLocked = stage > parseInt(clearedStage) + 1;
 
-  const backGroundColor = (stage: number): string => {
-    // Tailwindはクライアントサイドでのランタイムを考慮しないため、クラス名は静的である必要がある。
-    const colors: { [key: number]: string } = {
-      1: 'bg-stage-1',
-      2: 'bg-stage-2',
-      3: 'bg-stage-3',
-      4: 'bg-stage-4',
-      5: 'bg-stage-5',
-      6: 'bg-stage-6',
-      7: 'bg-stage-7',
-      8: 'bg-stage-8',
-      9: 'bg-stage-9',
-      10: 'bg-stage-10',
-    };
-
-    return colors[stage];
-  };
   const panelTestId = (stage: number): string => `stage-select-panel-${stage}`;
   if (isLocked) {
     return (

--- a/src/components/StageSelectPanel.tsx
+++ b/src/components/StageSelectPanel.tsx
@@ -17,20 +17,20 @@ function StageSelectPanel({ panelNumber, stage }: Props) {
 
   const backGroundColor = (stage: number): string => {
     // Tailwindはクライアントサイドでのランタイムを考慮しないため、クラス名は静的である必要がある。
-    const colors: string[] = [
-      'bg-stage-1',
-      'bg-stage-2',
-      'bg-stage-3',
-      'bg-stage-4',
-      'bg-stage-5',
-      'bg-stage-6',
-      'bg-stage-7',
-      'bg-stage-8',
-      'bg-stage-9',
-      'bg-stage-10',
-    ];
+    const colors: { [key: number]: string } = {
+      1: 'bg-stage-1',
+      2: 'bg-stage-2',
+      3: 'bg-stage-3',
+      4: 'bg-stage-4',
+      5: 'bg-stage-5',
+      6: 'bg-stage-6',
+      7: 'bg-stage-7',
+      8: 'bg-stage-8',
+      9: 'bg-stage-9',
+      10: 'bg-stage-10',
+    };
 
-    return colors[stage - 1];
+    return colors[stage];
   };
   const panelTestId = (stage: number): string => `stage-select-panel-${stage}`;
   if (isLocked) {

--- a/src/components/WordplayTile.tsx
+++ b/src/components/WordplayTile.tsx
@@ -2,13 +2,15 @@ import Image from 'next/image';
 import NumberTile from './NumberTile';
 
 import { MODE, Mode, wordplayTile } from '../pages/stages/[stage]';
+import { backGroundColor } from './StageSelectPanel';
 
 type Props = {
   mode: Mode;
   tile: wordplayTile;
+  stageNumber: string;
 };
 
-const WordplayTile = ({ mode, tile }: Props) => {
+const WordplayTile = ({ mode, tile, stageNumber }: Props) => {
   const wordplayImageSrc = () => {
     const str: string = tile.numbers
       .map((eachNumber) => eachNumber.value)
@@ -44,7 +46,11 @@ const WordplayTile = ({ mode, tile }: Props) => {
       }`}
     >
       <div className="h-full w-14 flex flex-col justify-between">
-        <div className="flex justify-center items-center h-14 bg-stage-1 rounded relative">
+        <div
+          className={`flex justify-center items-center h-14 ${backGroundColor(
+            parseInt(stageNumber),
+          )} rounded relative`}
+        >
           <div className="absolute flex justify-center items-center">
             <Image
               src={wordplayImageSrc()}

--- a/src/components/Wordplays.tsx
+++ b/src/components/Wordplays.tsx
@@ -4,13 +4,14 @@ import { Mode, wordplayTile } from '../pages/stages/[stage]';
 type Props = {
   mode: Mode;
   tiles: wordplayTile[];
+  stageNumber: string;
 };
 
-const Wordplays = ({ mode, tiles }: Props) => {
+const Wordplays = ({ mode, tiles, stageNumber }: Props) => {
   const wordplayTiles = tiles.map((tile, index) => {
     return (
       <li key={index}>
-        <WordplayTile mode={mode} tile={tile} />
+        <WordplayTile mode={mode} tile={tile} stageNumber={stageNumber} />
       </li>
     );
   });

--- a/src/hooks/useClearedStage.ts
+++ b/src/hooks/useClearedStage.ts
@@ -1,0 +1,28 @@
+import { useCallback, useEffect, useState } from 'react';
+
+const STORAGE_KEY_CLEARED_STAGE = 'gorogoropanda.com/clearedStage';
+
+export function useClearedStage(
+  defaultValue: number,
+): [clearedStage: string, setClearedStage: (clearedStage: string) => void] {
+  const [clearedStageInternal, setClearedStageInternal] = useState('0');
+
+  useEffect(() => {
+    const storageClearedStage = localStorage.getItem(STORAGE_KEY_CLEARED_STAGE);
+    const clearedStage: string =
+      storageClearedStage === null ? '' : storageClearedStage;
+    if (parseInt(clearedStage) > defaultValue) {
+      setClearedStageInternal(clearedStage);
+    }
+  }, [setClearedStageInternal]);
+
+  const setClearedStage = useCallback(
+    (clearedStage: string) => {
+      localStorage.setItem(STORAGE_KEY_CLEARED_STAGE, clearedStage);
+      setClearedStageInternal(clearedStage);
+    },
+    [setClearedStageInternal],
+  );
+
+  return [clearedStageInternal, setClearedStage];
+}

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -1,10 +1,19 @@
+import { useEffect } from 'react';
 import type { AppProps } from 'next/app';
 import { DefaultSeo, NextSeo } from 'next-seo';
 
 import '../styles/globals.css';
 import SEO from '../../next-seo.config';
 
+export const clearedStage = 'clearedStage';
+
 function MyApp({ Component, pageProps }: AppProps) {
+  useEffect(() => {
+    if (!Object.prototype.hasOwnProperty.call(localStorage, clearedStage)) {
+      localStorage.setItem(clearedStage, '0');
+    }
+  }, []);
+
   return (
     <>
       <DefaultSeo {...SEO} />

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -1,4 +1,3 @@
-import { useEffect } from 'react';
 import type { AppProps } from 'next/app';
 import { DefaultSeo, NextSeo } from 'next-seo';
 
@@ -8,12 +7,6 @@ import SEO from '../../next-seo.config';
 export const clearedStage = 'clearedStage';
 
 function MyApp({ Component, pageProps }: AppProps) {
-  useEffect(() => {
-    if (!Object.prototype.hasOwnProperty.call(localStorage, clearedStage)) {
-      localStorage.setItem(clearedStage, '0');
-    }
-  }, []);
-
   return (
     <>
       <DefaultSeo {...SEO} />

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -8,9 +8,6 @@ export const piNumber =
 
 const Home: NextPage = () => {
   const panelNumbers = piNumber.match(/.{10}/g)!;
-  const isLocked = (index: number): boolean => {
-    return index !== 0;
-  };
 
   return (
     <div>
@@ -19,11 +16,7 @@ const Home: NextPage = () => {
         <ul className="flex flex-col">
           {panelNumbers.map((panelNumber: string, index: number) => (
             <li key={index}>
-              <StageSelectPanel
-                panelNumber={panelNumber}
-                stage={index + 1}
-                isLocked={isLocked(index)}
-              />
+              <StageSelectPanel panelNumber={panelNumber} stage={index + 1} />
             </li>
           ))}
         </ul>

--- a/src/pages/stages/[stage].tsx
+++ b/src/pages/stages/[stage].tsx
@@ -11,6 +11,7 @@ import Button from '../../components/Button';
 import Modal from '../../components/Modal';
 import { piNumber } from '../index';
 import { useClearedStage } from '../../hooks/useClearedStage';
+import { useRouter } from 'next/router';
 
 interface Params extends ParsedUrlQuery {
   stage: string;
@@ -113,9 +114,20 @@ const Stage = ({ stageNumber }: Props) => {
     });
   }, [defaultNumberState, getStagePiNumber]);
 
+  const dynamicRoute = useRouter().asPath;
+
   useEffect(() => {
+    setScore(0);
+    setMode(MODE.Remember);
+    setCondition(CONDITION.Normal);
     setWordplayTiles(initialWordplayTiles());
-  }, []);
+    setLevel(1);
+    setTargetIndexesCombinations([]);
+  }, [dynamicRoute]);
+
+  // useEffect(() => {
+  //   setWordplayTiles(initialWordplayTiles());
+  // }, []);
 
   useEffect(() => {
     if (mode !== MODE.Clear || typeof window === 'undefined') return;

--- a/src/pages/stages/[stage].tsx
+++ b/src/pages/stages/[stage].tsx
@@ -10,7 +10,7 @@ import Instruction from '../../components/Instruction';
 import Button from '../../components/Button';
 import Modal from '../../components/Modal';
 import { piNumber } from '../index';
-import { clearedStage } from '../_app';
+import { useClearedStage } from '../../hooks/useClearedStage';
 
 interface Params extends ParsedUrlQuery {
   stage: string;
@@ -79,6 +79,7 @@ const Stage = ({ stageNumber }: Props) => {
   const [targetIndexesCombinations, setTargetIndexesCombinations] = useState<
     number[][]
   >([]);
+  const [clearedStage, setClearedStage] = useClearedStage(0);
 
   const getStagePiNumber = () => {
     const startIndex = stagePiNumberLength * (parseInt(stageNumber) - 1);
@@ -119,9 +120,9 @@ const Stage = ({ stageNumber }: Props) => {
   useEffect(() => {
     if (mode !== MODE.Clear || typeof window === 'undefined') return;
     const currentStageNumber = parseInt(stageNumber);
-    const clearedStageNumber = parseInt(localStorage.getItem(clearedStage)!);
+    const clearedStageNumber = parseInt(clearedStage);
     if (currentStageNumber > clearedStageNumber) {
-      localStorage.setItem('clearedStage', stageNumber);
+      setClearedStage(stageNumber);
     }
   }, [mode]);
 

--- a/src/pages/stages/[stage].tsx
+++ b/src/pages/stages/[stage].tsx
@@ -436,7 +436,11 @@ const Stage = ({ stageNumber }: Props) => {
         />
         <StageDescription stageNumber={stageNumber} />
         <Score score={score} />
-        <Wordplays mode={mode} tiles={wordplayTiles} />
+        <Wordplays
+          mode={mode}
+          tiles={wordplayTiles}
+          stageNumber={stageNumber}
+        />
         <Instruction condition={condition} mode={mode} />
         <Button handleOnClick={handleOnClick} />
         {/*<button onClick={toggleModal} className="mt-8 border-2 p-2 text-xl">toggle modal for debug</button>*/}

--- a/src/pages/stages/[stage].tsx
+++ b/src/pages/stages/[stage].tsx
@@ -3,13 +3,14 @@ import { ParsedUrlQuery } from 'querystring';
 import { GetStaticProps, GetStaticPaths } from 'next';
 import { NextSeo } from 'next-seo';
 
-import { piNumber } from '../index';
 import StageDescription from '../../components/StageDescription';
 import Score from '../../components/Score';
 import Wordplays from '../../components/Wordplays';
 import Instruction from '../../components/Instruction';
 import Button from '../../components/Button';
 import Modal from '../../components/Modal';
+import { piNumber } from '../index';
+import { clearedStage } from '../_app';
 
 interface Params extends ParsedUrlQuery {
   stage: string;
@@ -114,6 +115,15 @@ const Stage = ({ stageNumber }: Props) => {
   useEffect(() => {
     setWordplayTiles(initialWordplayTiles());
   }, []);
+
+  useEffect(() => {
+    if (mode !== MODE.Clear || typeof window === 'undefined') return;
+    const currentStageNumber = parseInt(stageNumber);
+    const clearedStageNumber = parseInt(localStorage.getItem(clearedStage)!);
+    if (currentStageNumber > clearedStageNumber) {
+      localStorage.setItem('clearedStage', stageNumber);
+    }
+  }, [mode]);
 
   const arrayEqual = useCallback((a: number[], b: number[]) => {
     if (!Array.isArray(a)) return false;


### PR DESCRIPTION
closes #39 

## 概要
- ローカルストレージを用い、クリア済みのステージを管理し、それに応じてステージをアンロックするようにした
- 各ステージのタイルの背景色が、ステージカラーに応じたものになるようにした
- モーダルから「次のステージへ」を選択した際、次のステージをプレイできるようにした

---

PR提出前のチェックリスト：
- [x] 関連するコミットをsquashした
