### PR TITLE
`Text content did not match.`という Warning を解消した

### DIFF
--- a/src/pages/stages/[stage].tsx
+++ b/src/pages/stages/[stage].tsx
@@ -1,4 +1,3 @@
-// import { useRef, useState, useEffect, FormEvent, useCallback } from 'react';
 import { useState, useEffect, useCallback } from 'react';
 import { ParsedUrlQuery } from 'querystring';
 import { GetStaticProps, GetStaticPaths } from 'next';

--- a/src/pages/stages/[stage].tsx
+++ b/src/pages/stages/[stage].tsx
@@ -2,17 +2,19 @@ import { useState, useEffect, useCallback } from 'react';
 import { ParsedUrlQuery } from 'querystring';
 import { GetStaticProps, GetStaticPaths } from 'next';
 import { NextSeo } from 'next-seo';
+import dynamic from 'next/dynamic';
 
 import StageDescription from '../../components/StageDescription';
 import Score from '../../components/Score';
 import Wordplays from '../../components/Wordplays';
 import Instruction from '../../components/Instruction';
 import Button from '../../components/Button';
-import Modal from '../../components/Modal';
 import { piNumber } from '../index';
 import { useClearedStage } from '../../hooks/useClearedStage';
 import { useRouter } from 'next/router';
 import Keyboard from '../../components/Keyboard';
+
+const Modal = dynamic(() => import('../../components/Modal'), { ssr: false });
 
 interface Params extends ParsedUrlQuery {
   stage: string;


### PR DESCRIPTION
closes #99 

## 概要
モーダルの生成にMath.random()を使っているのが原因で、サーバー側とクライアント側で内容に不一致が生じてしまっていた。
モーダルを動的にインポートし、SSR させないようにすることで、解消した。