### PR TITLE
スコアの幅を他のコンポーネントの幅に合わせた / スコアアップ時のアニメーションを実装した

### DIFF
--- a/src/components/Button.tsx
+++ b/src/components/Button.tsx
@@ -8,7 +8,7 @@ const Button = ({ handleOnClick }: Props) => {
       {/*buttonタグ + 小杉丸ゴシックフォントの組み合わせだと、スマホでのみ、１文字目（「覚」）が他の文字より明るくなるというバグに遭遇したため、divにしてある*/}
       <div
         onClick={handleOnClick}
-        className="flex items-center justify-center font-kosugi-maru rounded-lg h-14 w-28 border-2 border-white bg-ok text-lg font-bold mt-8"
+        className="flex items-center justify-center font-kosugi-maru rounded-lg h-14 w-28 border-2 border-white bg-ok text-lg font-bold"
       >
         覚えた！
       </div>

--- a/src/components/Button.tsx
+++ b/src/components/Button.tsx
@@ -4,12 +4,15 @@ type Props = {
 
 const Button = ({ handleOnClick }: Props) => {
   return (
-    <button
-      onClick={handleOnClick}
-      className="rounded-lg h-14 w-28 border-2 border-white bg-ok text-lg font-bold mt-8 font-kosugi-maru"
-    >
-      覚えた！
-    </button>
+    <>
+      {/*buttonタグ + 小杉丸ゴシックフォントの組み合わせだと、スマホでのみ、１文字目（「覚」）が他の文字より明るくなるというバグに遭遇したため、divにしてある*/}
+      <div
+        onClick={handleOnClick}
+        className="flex items-center justify-center font-kosugi-maru rounded-lg h-14 w-28 border-2 border-white bg-ok text-lg font-bold mt-8"
+      >
+        覚えた！
+      </div>
+    </>
   );
 };
 

--- a/src/components/Instruction.tsx
+++ b/src/components/Instruction.tsx
@@ -167,7 +167,7 @@ const Instruction = ({ condition, mode, level, firstTargetNumber }: Props) => {
   }, [level, mode, firstTargetNumber]);
 
   return (
-    <div className="flex justify-between w-full mt-3">
+    <div className="mb-10 flex justify-between w-full">
       {imageOnCondition()}
       <div className="flex flex-col justify-center items-center bg-white rounded-lg py-1 px-3 w-60 font-kosugi-maru">
         <div>

--- a/src/components/Instruction.tsx
+++ b/src/components/Instruction.tsx
@@ -74,7 +74,7 @@ const Instruction = ({ condition, mode, level, firstTargetNumber }: Props) => {
 
   const imageOnCondition = useCallback(() => {
     return (
-      <div className="pointer-events-none">
+      <div className="pointer-events-none w-20">
         <Image
           src={imgSrc(condition)}
           objectFit="contain"
@@ -167,7 +167,7 @@ const Instruction = ({ condition, mode, level, firstTargetNumber }: Props) => {
   }, [level, mode, firstTargetNumber]);
 
   return (
-    <div className="flex justify-between w-80 mt-3">
+    <div className="flex justify-between w-full mt-3">
       {imageOnCondition()}
       <div className="flex flex-col justify-center items-center bg-white rounded-lg py-1 px-3 w-60 font-kosugi-maru">
         <div>

--- a/src/components/Keyboard.tsx
+++ b/src/components/Keyboard.tsx
@@ -22,7 +22,7 @@ const Keyboard = ({ handleInputNumber: handleInputNumber }: Props) => {
     );
   }
 
-  return <div className="w-full mt-3">{keyRows}</div>;
+  return <div className="w-full">{keyRows}</div>;
 };
 
 export default Keyboard;

--- a/src/components/Keyboard.tsx
+++ b/src/components/Keyboard.tsx
@@ -16,16 +16,13 @@ const Keyboard = ({ handleInputNumber: handleInputNumber }: Props) => {
   const keyRows = [];
   for (let i = 0; i < keys.length; i += keys.length / 2) {
     keyRows.push(
-      <div
-        className={`w-80 flex justify-between ${i === 0 ? '' : 'mt-2'}`}
-        key={i}
-      >
+      <div className={`flex justify-between ${i === 0 ? '' : 'mt-2'}`} key={i}>
         {keys.slice(i, i + keys.length / 2)}
       </div>,
     );
   }
 
-  return <div className="mt-3">{keyRows}</div>;
+  return <div className="w-full mt-3">{keyRows}</div>;
 };
 
 export default Keyboard;

--- a/src/components/Modal.tsx
+++ b/src/components/Modal.tsx
@@ -59,7 +59,7 @@ const Modal = ({ visible, nextStageNumber }: Props) => {
         visible ? 'scale-110' : 'invisible'
       }`}
     >
-      <div className="flex flex-col items-center absolute top-20 bg-white w-80 h-72 rounded-md">
+      <div className="flex flex-col items-center absolute top-44 bg-white w-80 h-72 rounded-md">
         <div className="relative h-56">
           <div className="pointer-events-none">
             <Image
@@ -72,8 +72,9 @@ const Modal = ({ visible, nextStageNumber }: Props) => {
               onMouseDown={(e) => e.preventDefault()}
             />
           </div>
+          {/*<div className="flex flex-col absolute top-1/2 -translate-y-1/2 left-1/2 -translate-x-1/2">*/}
           <div className="flex flex-col absolute top-1/2 -translate-y-1/2 left-1/2 -translate-x-1/2">
-            <h1 className="text-base text-center font-bold">
+            <h1 className="text-base text-center font-bold block">
               🎉クリア、おめでとう！🎉
             </h1>
             <div className="flex mt-2">

--- a/src/components/Modal.tsx
+++ b/src/components/Modal.tsx
@@ -59,7 +59,7 @@ const Modal = ({ visible, nextStageNumber }: Props) => {
         visible ? 'scale-110' : 'invisible'
       }`}
     >
-      <div className="flex flex-col items-center absolute top-44 bg-white w-80 h-72 rounded-md">
+      <div className="flex flex-col items-center absolute top-36 bg-white w-80 h-72 rounded-md">
         <div className="relative h-56">
           <div className="pointer-events-none">
             <Image
@@ -72,18 +72,17 @@ const Modal = ({ visible, nextStageNumber }: Props) => {
               onMouseDown={(e) => e.preventDefault()}
             />
           </div>
-          {/*<div className="flex flex-col absolute top-1/2 -translate-y-1/2 left-1/2 -translate-x-1/2">*/}
-          <div className="flex flex-col absolute top-1/2 -translate-y-1/2 left-1/2 -translate-x-1/2">
-            <h1 className="text-base text-center font-bold block">
+          <div className="flex flex-col items-center absolute top-0 left-0 w-full">
+            <h1 className="mt-12 mb-2 text-base font-bold">
               🎉クリア、おめでとう！🎉
             </h1>
-            <div className="flex mt-2">
+            <div className="flex w-full ml-28">
               <div className="pointer-events-none">
                 <Image
                   src="/pandas/panda_happy_1.png"
                   objectFit="contain"
-                  width={90}
-                  height={100}
+                  width={70}
+                  height={80}
                   alt="panda"
                   onContextMenu={(e) => e.preventDefault()}
                   onMouseDown={(e) => e.preventDefault()}

--- a/src/components/Score.tsx
+++ b/src/components/Score.tsx
@@ -34,7 +34,7 @@ const Score = ({ score }: Props) => {
 
   return (
     <div>
-      <ul className="flex pointer-events-none">{marks}</ul>
+      <ul className="mb-6 flex pointer-events-none">{marks}</ul>
     </div>
   );
 };

--- a/src/components/Score.tsx
+++ b/src/components/Score.tsx
@@ -10,8 +10,8 @@ const Score = ({ score }: Props) => {
     <Image
       src="/star_yellow.png"
       alt="yellow star"
-      width={22}
-      height={22}
+      width={21}
+      height={21}
       onContextMenu={(e) => e.preventDefault()}
       onMouseDown={(e) => e.preventDefault()}
     />
@@ -20,8 +20,8 @@ const Score = ({ score }: Props) => {
     <Image
       src="/star_gray.png"
       alt="gray star"
-      width={22}
-      height={22}
+      width={21}
+      height={21}
       onContextMenu={(e) => e.preventDefault()}
       onMouseDown={(e) => e.preventDefault()}
     />

--- a/src/components/Score.tsx
+++ b/src/components/Score.tsx
@@ -1,42 +1,24 @@
-import Image from 'next/image';
-
 import { maxScore } from '../pages/stages/[stage]';
+import Star from './Star';
 
 type Props = {
   score: number;
 };
 const Score = ({ score }: Props) => {
-  const starYellow = (
-    <Image
-      src="/star_yellow.png"
-      alt="yellow star"
-      width={21}
-      height={21}
-      onContextMenu={(e) => e.preventDefault()}
-      onMouseDown={(e) => e.preventDefault()}
-    />
-  );
-  const starGray = (
-    <Image
-      src="/star_gray.png"
-      alt="gray star"
-      width={21}
-      height={21}
-      onContextMenu={(e) => e.preventDefault()}
-      onMouseDown={(e) => e.preventDefault()}
-    />
-  );
-  const star = (index: number) => (index < score ? starYellow : starGray);
+  const isBright = (index: number) => {
+    return index < score;
+  };
+
   const marks = [];
   for (let i = 0; i < maxScore; i++) {
-    marks.push(<li key={i}>{star(i)}</li>);
+    marks.push(
+      <li key={i}>
+        <Star isBright={isBright(i)} />
+      </li>,
+    );
   }
 
-  return (
-    <div>
-      <ul className="mb-6 flex pointer-events-none">{marks}</ul>
-    </div>
-  );
+  return <ul className="mb-6 flex">{marks}</ul>;
 };
 
 export default Score;

--- a/src/components/StageDescription.tsx
+++ b/src/components/StageDescription.tsx
@@ -33,7 +33,7 @@ const StageDescription = ({ stageNumber }: Props) => {
   };
 
   return (
-    <h1 className="mt-1 flex font-kosugi-maru">
+    <h1 className="mb-3 flex font-kosugi-maru">
       {displayStage(stageNumber)}
       <span className="ml-4" />
       {displayDigitsRange(parseInt(stageNumber))}

--- a/src/components/Star.tsx
+++ b/src/components/Star.tsx
@@ -1,0 +1,42 @@
+import Image from 'next/image';
+
+type Props = {
+  isBright: boolean;
+};
+
+const Star = ({ isBright }: Props) => {
+  return (
+    <>
+      <div className="flex justify-center items-center relative pointer-events-none">
+        <div className="absolute flex justify-center items-center">
+          <Image
+            src="/star_yellow.png"
+            width={21}
+            height={21}
+            objectFit="contain"
+            alt="yellow star"
+            onContextMenu={(e) => e.preventDefault()}
+            onMouseDown={(e) => e.preventDefault()}
+            className={`transition-all ease-in duration-200 ${
+              isBright ? 'delay-200 rotate-y-0' : 'rotate-y-90'
+            }`}
+          />
+        </div>
+        <Image
+          src="/star_gray.png"
+          width={21}
+          height={21}
+          objectFit="contain"
+          alt="gray star"
+          onContextMenu={(e) => e.preventDefault()}
+          onMouseDown={(e) => e.preventDefault()}
+          className={`transition-all ease-in duration-200 ${
+            isBright ? 'rotate-y-90' : 'rotate-y-0 delay-200'
+          }`}
+        />
+      </div>
+    </>
+  );
+};
+
+export default Star;

--- a/src/components/Wordplays.tsx
+++ b/src/components/Wordplays.tsx
@@ -16,7 +16,7 @@ const Wordplays = ({ mode, tiles, stageNumber }: Props) => {
     );
   });
 
-  return <ul className="flex w-80 mt-1">{wordplayTiles}</ul>;
+  return <ul className="flex w-full mt-1">{wordplayTiles}</ul>;
 };
 
 export default Wordplays;

--- a/src/components/Wordplays.tsx
+++ b/src/components/Wordplays.tsx
@@ -16,7 +16,7 @@ const Wordplays = ({ mode, tiles, stageNumber }: Props) => {
     );
   });
 
-  return <ul className="flex w-full mt-1">{wordplayTiles}</ul>;
+  return <ul className="mb-10 flex w-full">{wordplayTiles}</ul>;
 };
 
 export default Wordplays;

--- a/src/pages/stages/[stage].tsx
+++ b/src/pages/stages/[stage].tsx
@@ -449,7 +449,7 @@ const Stage = ({ stageNumber }: Props) => {
         nextStageNumber={nextStageNumber()}
       />
       <div className="flex justify-center">
-        <div className="w-80 flex flex-col items-center text-white">
+        <div className="w-80 py-6 flex flex-col items-center text-white">
           <StageDescription stageNumber={stageNumber} />
           <Score score={score} />
           <Wordplays

--- a/src/pages/stages/[stage].tsx
+++ b/src/pages/stages/[stage].tsx
@@ -448,25 +448,27 @@ const Stage = ({ stageNumber }: Props) => {
         visible={mode === MODE.Clear}
         nextStageNumber={nextStageNumber()}
       />
-      <div className="flex flex-col items-center text-white">
-        <StageDescription stageNumber={stageNumber} />
-        <Score score={score} />
-        <Wordplays
-          mode={mode}
-          tiles={wordplayTiles}
-          stageNumber={stageNumber}
-        />
-        <Instruction
-          condition={condition}
-          mode={mode}
-          level={level}
-          firstTargetNumber={firstTargetNumber()}
-        />
-        {mode === MODE.Remember ? (
-          <Button handleOnClick={handleOnClick} />
-        ) : (
-          <Keyboard handleInputNumber={handleInputNumber} />
-        )}
+      <div className="flex justify-center">
+        <div className="w-80 flex flex-col items-center text-white">
+          <StageDescription stageNumber={stageNumber} />
+          <Score score={score} />
+          <Wordplays
+            mode={mode}
+            tiles={wordplayTiles}
+            stageNumber={stageNumber}
+          />
+          <Instruction
+            condition={condition}
+            mode={mode}
+            level={level}
+            firstTargetNumber={firstTargetNumber()}
+          />
+          {mode === MODE.Remember ? (
+            <Button handleOnClick={handleOnClick} />
+          ) : (
+            <Keyboard handleInputNumber={handleInputNumber} />
+          )}
+        </div>
       </div>
     </>
   );

--- a/src/pages/stages/[stage].tsx
+++ b/src/pages/stages/[stage].tsx
@@ -418,16 +418,6 @@ const Stage = ({ stageNumber }: Props) => {
     };
   }, [keyPress]);
 
-  // const toggleModal = useCallback(() => {
-  //   setMode((prevMode) => {
-  //     if (prevMode === MODE.Clear) {
-  //       return MODE.Remember;
-  //     } else {
-  //       return MODE.Clear;
-  //     }
-  //   });
-  // }, []);
-
   const nextStageNumber = () => {
     return parseInt(stageNumber) + 1;
   };
@@ -440,6 +430,16 @@ const Stage = ({ stageNumber }: Props) => {
 
     return '';
   }, [wordplayTiles]);
+
+  // const toggleModal = useCallback(() => {
+  //   setMode((prevMode) => {
+  //     if (prevMode === MODE.Clear) {
+  //       return MODE.Remember;
+  //     } else {
+  //       return MODE.Clear;
+  //     }
+  //   });
+  // }, []);
 
   return (
     <>
@@ -468,6 +468,9 @@ const Stage = ({ stageNumber }: Props) => {
           ) : (
             <Keyboard handleInputNumber={handleInputNumber} />
           )}
+          {/*<button onClick={toggleModal} className="mt-8 border-2 p-2 text-xl">*/}
+          {/*  toggle modal for debug*/}
+          {/*</button>*/}
         </div>
       </div>
     </>


### PR DESCRIPTION
closes #105 

## 概要
- スコアのコンポーネントのみ、他のコンポーネントよりも幅が長くなっている状態を解決した
- スコアアップ時にアニメーションが発生するようにした

---

PR提出前のチェックリスト：
- [x] 関連するコミットをsquashした
