### PR TITLE
Feature/refine stage select panel appearance

### DIFF
--- a/src/components/StageSelectPanel.tsx
+++ b/src/components/StageSelectPanel.tsx
@@ -34,6 +34,7 @@ function StageSelectPanel({ panelNumber, stage }: Props) {
   const isLocked = stage > parseInt(clearedStage) + 1;
 
   const panelTestId = (stage: number): string => `stage-select-panel-${stage}`;
+  // Linkタグにhrefを指定しないとWarningが出るため、冗長ではあるが２パターンに書き分けている
   if (isLocked) {
     return (
       <div

--- a/src/components/StageSelectPanelContent.tsx
+++ b/src/components/StageSelectPanelContent.tsx
@@ -11,7 +11,7 @@ const StageSelectPanelContent = ({ panelNumber, stage, isLocked }: Props) => {
   const stageIndicator = (
     <div className="w-16 flex flex-col items-center">
       <p className="text-white text-xs scale-75">ステージ</p>
-      <div className="flex h-9 w-9 justify-center items-center text-black text-2xl font-varela-round bg-white rounded-full">
+      <div className="h-9 w-9 flex justify-center items-center text-black text-2xl font-varela-round bg-white rounded-full">
         {stage}
       </div>
     </div>

--- a/src/components/StageSelectPanelContent.tsx
+++ b/src/components/StageSelectPanelContent.tsx
@@ -8,21 +8,33 @@ type Props = {
 const StageSelectPanelContent = ({ panelNumber, stage, isLocked }: Props) => {
   const tileNumbers = panelNumber.match(/.{2}/g)!;
 
-  return (
-    <div className="w-full flex items-center px-2">
-      <div className="w-16 flex flex-col items-center">
-        <p className="text-white text-xs scale-75">ステージ</p>
-        <div className="flex h-9 w-9 justify-center items-center text-black text-2xl font-varela-round bg-white rounded-full">
-          {stage}
-        </div>
+  const stageIndicator = (
+    <div className="w-16 flex flex-col items-center">
+      <p className="text-white text-xs scale-75">ステージ</p>
+      <div className="flex h-9 w-9 justify-center items-center text-black text-2xl font-varela-round bg-white rounded-full">
+        {stage}
       </div>
-      <ul className="w-full flex justify-between">
-        {tileNumbers.map((tileNumber: string, index: number) => (
-          <li key={index}>
-            <StageSelectTile tileNumber={tileNumber} isLocked={isLocked} />
-          </li>
-        ))}
-      </ul>
+    </div>
+  );
+
+  const tiles = (
+    <ul className="w-full flex justify-between relative ml-1">
+      {tileNumbers.map((tileNumber: string, index: number) => (
+        <li key={index}>
+          <StageSelectTile
+            tileNumber={tileNumber}
+            isLocked={isLocked}
+            firstTile={stage === 1 && index === 0}
+          />
+        </li>
+      ))}
+    </ul>
+  );
+
+  return (
+    <div className="w-full flex items-center pl-2 pr-3 relative">
+      {stageIndicator}
+      {tiles}
     </div>
   );
 };

--- a/src/components/StageSelectPanelContent.tsx
+++ b/src/components/StageSelectPanelContent.tsx
@@ -9,18 +9,21 @@ const StageSelectPanelContent = ({ panelNumber, stage, isLocked }: Props) => {
   const tileNumbers = panelNumber.match(/.{2}/g)!;
 
   return (
-    <>
-      <div className="text-white text-xl mt-7 ml-7 font-varela-round">
-        {stage}
+    <div className="w-full flex items-center px-2">
+      <div className="w-16 flex flex-col items-center">
+        <p className="text-white text-xs scale-75">ステージ</p>
+        <div className="flex h-9 w-9 justify-center items-center text-black text-2xl font-varela-round bg-white rounded-full">
+          {stage}
+        </div>
       </div>
-      <ul className="flex">
+      <ul className="w-full flex justify-between">
         {tileNumbers.map((tileNumber: string, index: number) => (
           <li key={index}>
             <StageSelectTile tileNumber={tileNumber} isLocked={isLocked} />
           </li>
         ))}
       </ul>
-    </>
+    </div>
   );
 };
 

--- a/src/components/StageSelectTile.tsx
+++ b/src/components/StageSelectTile.tsx
@@ -6,19 +6,32 @@ type Props = {
   firstTile: boolean;
 };
 function StageSelectTile({ tileNumber, isLocked, firstTile }: Props) {
-  const srcPath = (isLocked: boolean, tileNumber: string): string => {
-    if (isLocked) return '/mark_question.png';
-
+  const srcPath = (tileNumber: string): string => {
     return `/wordplays/${tileNumber}.png`;
   };
 
   const piStartIndicator = <div className="absolute -ml-3">3.</div>;
 
-  return (
-    <>
-      <div className="pointer-events-none">
+  const questionImage = (
+    <div className="absolute z-10">
+      <Image
+        src="/mark_question.png"
+        width={50}
+        height={50}
+        objectFit="contain"
+        alt="wordplay"
+        onContextMenu={(e) => e.preventDefault()}
+        onMouseDown={(e) => e.preventDefault()}
+      />
+    </div>
+  );
+
+  const image = (
+    <div className="pointer-events-none relative">
+      {isLocked ? questionImage : null}
+      <div className={`${isLocked ? 'brightness-0 invert blur-xs' : ''}`}>
         <Image
-          src={srcPath(isLocked, tileNumber)}
+          src={srcPath(tileNumber)}
           width={50}
           height={50}
           objectFit="contain"
@@ -27,10 +40,20 @@ function StageSelectTile({ tileNumber, isLocked, firstTile }: Props) {
           onMouseDown={(e) => e.preventDefault()}
         />
       </div>
-      <div className="text-center text-white text-2xl font-varela-round -mt-2 relative">
-        {firstTile ? piStartIndicator : null}
-        {tileNumber}
-      </div>
+    </div>
+  );
+
+  const number = (
+    <div className="text-center text-white text-2xl font-varela-round -mt-2">
+      {firstTile ? piStartIndicator : null}
+      {tileNumber}
+    </div>
+  );
+
+  return (
+    <>
+      {image}
+      {number}
     </>
   );
 }

--- a/src/components/StageSelectTile.tsx
+++ b/src/components/StageSelectTile.tsx
@@ -3,13 +3,16 @@ import Image from 'next/image';
 type Props = {
   tileNumber: string;
   isLocked: boolean;
+  firstTile: boolean;
 };
-function StageSelectTile({ tileNumber, isLocked }: Props) {
+function StageSelectTile({ tileNumber, isLocked, firstTile }: Props) {
   const srcPath = (isLocked: boolean, tileNumber: string): string => {
     if (isLocked) return '/mark_question.png';
 
     return `/wordplays/${tileNumber}.png`;
   };
+
+  const piStartIndicator = <div className="absolute -ml-3">3.</div>;
 
   return (
     <>
@@ -24,7 +27,8 @@ function StageSelectTile({ tileNumber, isLocked }: Props) {
           onMouseDown={(e) => e.preventDefault()}
         />
       </div>
-      <div className="text-center text-white text-2xl font-varela-round -mt-2">
+      <div className="text-center text-white text-2xl font-varela-round -mt-2 relative">
+        {firstTile ? piStartIndicator : null}
         {tileNumber}
       </div>
     </>

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -18,6 +18,9 @@ module.exports = {
   ],
   theme: {
     extend: {
+      blur: {
+        xs: '2px',
+      },
       colors: {
         locked: '#b7d6e8',
         'stage-1': '#ff88bb',


### PR DESCRIPTION
closes #107 

## 概要
- ステージ番号にデザインを付けた
- ステージ１の最初のタイルの「14」の直前に「3.」と付記した
- ロック状態場合のクエスチョンマーク画像の背後に、本来の画像のシルエットを表示させた