### PR TITLE
Googleフォント読み込みを最適化した

### DIFF
--- a/src/pages/_document.tsx
+++ b/src/pages/_document.tsx
@@ -1,0 +1,49 @@
+import Document, {
+  Html,
+  Head,
+  Main,
+  NextScript,
+  DocumentContext,
+  DocumentInitialProps,
+} from 'next/document';
+import { NextPageContext } from 'next';
+import { RenderPage } from 'next/dist/shared/lib/utils';
+
+class MyDocument extends Document {
+  static async getInitialProps(
+    ctx: NextPageContext & {
+      renderPage: RenderPage;
+      defaultGetInitialProps(
+        ctx: DocumentContext,
+      ): Promise<DocumentInitialProps>;
+    },
+  ) {
+    const initialProps = await Document.getInitialProps(ctx);
+
+    return { ...initialProps };
+  }
+
+  render() {
+    return (
+      <Html>
+        <Head>
+          <link
+            href="https://fonts.googleapis.com/css2?family=Kosugi+Maru&display=swap"
+            rel="stylesheet"
+          />
+          <link
+            href="https://fonts.googleapis.com/css2?family=Varela+Round&display=swap"
+            rel="stylesheet"
+          />
+          <title>ゴロゴロ円周率</title>
+        </Head>
+        <body>
+          <Main />
+          <NextScript />
+        </body>
+      </Html>
+    );
+  }
+}
+
+export default MyDocument;

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -1,6 +1,3 @@
-@import url('https://fonts.googleapis.com/css2?family=Kosugi+Maru&display=swap');
-@import url('https://fonts.googleapis.com/css2?family=Varela+Round&display=swap');
-
 @tailwind base;
 @tailwind components;
 @tailwind utilities;


### PR DESCRIPTION
closes #131 

## 概要
これまでの Google フォント読み込みは`src/styles/globals.css`内で行なっていたが、それだと読み込み時に最適化がなされておらず、反映までに遅延を生じさせていることが分かった。
これをを解決した。

## 参考 URL
https://nextjs.org/docs/basic-features/font-optimization
https://nextjs.org/docs/advanced-features/custom-document