### PR TITLE
アンロックされていないURLにアクセスするとルートへリダイレクトされるようにした

### DIFF
--- a/src/components/StageSelectPanel.tsx
+++ b/src/components/StageSelectPanel.tsx
@@ -29,7 +29,7 @@ export const backGroundColor = (stage: number): string => {
 export const stagePath = (stage: number): string => `/stages/${stage}`;
 
 function StageSelectPanel({ panelNumber, stage }: Props) {
-  const clearedStage = useClearedStage(0)[0];
+  const clearedStage = useClearedStage('0')[0];
 
   const isLocked = stage > parseInt(clearedStage) + 1;
 

--- a/src/hooks/useClearedStage.ts
+++ b/src/hooks/useClearedStage.ts
@@ -3,7 +3,7 @@ import { useCallback, useEffect, useState } from 'react';
 const STORAGE_KEY_CLEARED_STAGE = 'gorogoropanda.com/clearedStage';
 
 export function useClearedStage(
-  defaultValue: number,
+  defaultValue: string,
 ): [clearedStage: string, setClearedStage: (clearedStage: string) => void] {
   const [clearedStageInternal, setClearedStageInternal] = useState('0');
 
@@ -11,7 +11,7 @@ export function useClearedStage(
     const storageClearedStage = localStorage.getItem(STORAGE_KEY_CLEARED_STAGE);
     const clearedStage: string =
       storageClearedStage === null ? '' : storageClearedStage;
-    if (parseInt(clearedStage) > defaultValue) {
+    if (parseInt(clearedStage) > parseInt(defaultValue)) {
       setClearedStageInternal(clearedStage);
     }
   }, [setClearedStageInternal]);

--- a/src/pages/stages/[stage].tsx
+++ b/src/pages/stages/[stage].tsx
@@ -101,7 +101,17 @@ const Stage = ({ stageNumber }: Props) => {
     number[][]
   >([]);
   const [typeModeCount, setTypeModeCount] = useState(0);
-  const [clearedStage, setClearedStage] = useClearedStage(0);
+  const [clearedStage, setClearedStage] = useClearedStage('0');
+
+  const router = useRouter();
+
+  useEffect(() => {
+    if (parseInt(stageNumber) > parseInt(clearedStage) + 1) {
+      router.push('/').catch((e) => {
+        console.log(e);
+      });
+    }
+  }, [router, stageNumber]);
 
   const initialWordplayTiles = useCallback(() => {
     const getStagePiNumber = () => {

--- a/src/pages/thank-you-for-playing.tsx
+++ b/src/pages/thank-you-for-playing.tsx
@@ -1,8 +1,21 @@
 import Image from 'next/image';
-import React from 'react';
+import React, { useEffect } from 'react';
 import Link from 'next/link';
+import { useRouter } from 'next/router';
+import { useClearedStage } from '../hooks/useClearedStage';
 
 const ThankYouForPlaying = () => {
+  const clearedStage = useClearedStage('0')[0];
+  const router = useRouter();
+
+  useEffect(() => {
+    if (parseInt(clearedStage) < 10) {
+      router.push('/').catch((e) => {
+        console.log(e);
+      });
+    }
+  }, [router, clearedStage]);
+
   const sentences = [
     'いっぱい遊んでくれて、ありがとう！',
     'ここまで来られたなんて、きみは本当に努力家だね。',


### PR DESCRIPTION
closes #140 

## 概要
次の２つの場合に、表題通りに動作するようにした。
1. あるステージの URL にアクセスした際、その直前のステージのクリアが記録されていない場合
2. フィナーレページの URL にアクセスした際、ステージ 10 のクリアが記録されていない場合