### PR TITLE
フッターの背景色を無くし、クリック領域を広くした

### DIFF
--- a/src/components/stageSelect/Footer.tsx
+++ b/src/components/stageSelect/Footer.tsx
@@ -8,13 +8,13 @@ const Footer = () => {
   const iconSize = 16;
 
   return (
-    <footer className="flex justify-center items-center bg-black h-8 text-white">
-      <div className="flex items-center gap-x-3">
+    <footer className="flex justify-center items-center text-white py-3">
+      <div className="flex items-center gap-x-2.5">
         <p className="text-xs">&copy; 2022 {Site.developer}</p>
-        <div className="flex items-center gap-x-3">
+        <div className="flex items-center">
           <a
             href={Site.note}
-            className="flex justify-center items-center"
+            className="flex justify-center items-center p-2.5"
             target="_blank"
             rel="noopener noreferrer"
           >
@@ -32,12 +32,22 @@ const Footer = () => {
               }
             />
           </a>
-          <a href={Site.twitter} target="_blank" rel="noopener noreferrer">
+          <a
+            href={Site.twitter}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="p-2.5"
+          >
             <IconContext.Provider value={{ size: `${iconSize}px` }}>
               <FaTwitter />
             </IconContext.Provider>
           </a>
-          <a href={Site.github} target="_blank" rel="noopener noreferrer">
+          <a
+            href={Site.github}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="p-2.5"
+          >
             <IconContext.Provider value={{ size: `${iconSize}px` }}>
               <FaGithub />
             </IconContext.Provider>


### PR DESCRIPTION
closes #196 

## Before
<img width="350" alt="スクリーンショット 2022-03-16 17 43 47" src="https://user-images.githubusercontent.com/46347198/158550856-1ffc4ac2-952f-4b3a-83ba-f36afe40463e.png">

## After
<img width="350" alt="スクリーンショット 2022-03-16 17 43 32" src="https://user-images.githubusercontent.com/46347198/158550890-7092156b-2801-4db8-91f9-cd873d258d7a.png">