### PR TITLE
ボタンのデザインをリッチにした

### DIFF
--- a/src/components/stageSelect/ReviewStagePanel.tsx
+++ b/src/components/stageSelect/ReviewStagePanel.tsx
@@ -41,7 +41,6 @@ const ReviewStagePanel = ({
     clearedReviewValues,
   )[0];
 
-  console.log(clearedStage);
   const isLocked = clearedStage < 10 || reviewNumber > clearedReview + 1;
 
   const testId = `review-select-panel-${reviewNumber}`;

--- a/src/components/stages/Modal.tsx
+++ b/src/components/stages/Modal.tsx
@@ -186,7 +186,7 @@ const Modal = memo(function Modal({
 
   return (
     <div
-      className={`flex justify-center fixed w-full h-full bg-black bg-opacity-40 z-10 font-kosugi-maru ${
+      className={`flex justify-center fixed w-full h-full bg-black bg-opacity-40 z-20 font-kosugi-maru ${
         visible ? '' : 'invisible'
       }`}
     >

--- a/src/components/stages/Modal.tsx
+++ b/src/components/stages/Modal.tsx
@@ -136,18 +136,24 @@ const Modal = memo(function Modal({
   const shareButtonSize = 40;
 
   const snsButtons = (
-    <div className="flex flex-col gap-y-3">
+    <div className="flex justify-center gap-x-8 mt-2">
       <FacebookButton text={snsText()} size={shareButtonSize} />
       <TwitterButton text={snsText()} size={shareButtonSize} />
     </div>
   );
   const linkButtonClass =
-    'w-38 py-2 cursor-pointer rounded text-white font-bold text-center';
+    'relative w-48 py-3 cursor-pointer rounded-full text-white font-bold text-center border-4 border-white shadow-lg shadow-black/25';
+
+  const buttonLight = (
+    <span className="absolute top-1.5 left-3 w-40 h-5 bg-white opacity-30 rounded-full" />
+  );
+
   const stageSelectButton = (
     <Link href="/">
       <a
-        className={`${linkButtonClass} bg-gray-300 sm:hover:bg-gray-500 active:bg-gray-500`}
+        className={`${linkButtonClass} bg-gradient-to-b from-navy-darkest to-navy-darker sm:hover:bg-gray-500 active:bg-gray-500`}
       >
+        {buttonLight}
         ステージをえらぶ
       </a>
     </Link>
@@ -164,14 +170,15 @@ const Modal = memo(function Modal({
   const moveToNextButton = (
     <Link href={nextStagePath()}>
       <a
-        className={`${linkButtonClass} bg-green-400 sm:hover:bg-green-500 active:bg-green-500`}
+        className={`${linkButtonClass} bg-gradient-to-b from-ok-dark to-ok-light sm:hover:bg-green-500 active:bg-green-500`}
       >
+        {buttonLight}
         次に進む
       </a>
     </Link>
   );
   const linkButtons = (
-    <div className="flex flex-col gap-y-3">
+    <div className="flex flex-col items-center gap-y-3">
       {stageSelectButton}
       {moveToNextButton}
     </div>
@@ -184,7 +191,7 @@ const Modal = memo(function Modal({
       }`}
     >
       <div
-        className={`flex flex-col items-center absolute top-20 bg-white w-80 rounded-md ${
+        className={`flex flex-col items-center absolute top-24 bg-white w-80 rounded-md ${
           visible ? 'transition-all duration-200 scale-110' : 'scale-0'
         }`}
       >
@@ -203,9 +210,15 @@ const Modal = memo(function Modal({
             </div>
           </div>
         </div>
-        <div className="mt-6 my-4 mr-2 flex gap-x-8">
-          {snsButtons}
+        <div className="pt-3 pb-4 flex flex-col w-full items-center">
           {linkButtons}
+          <div className="flex flex-col text-xs mt-6">
+            <div className="flex flex-col text-gray-500">
+              <p>ステージクリア、おめでとう！</p>
+              <p>今の気持ちを友達とシェアしよう！</p>
+            </div>
+            {snsButtons}
+          </div>
         </div>
       </div>
     </div>

--- a/src/components/stages/ReviewButton.tsx
+++ b/src/components/stages/ReviewButton.tsx
@@ -7,8 +7,9 @@ const ReviewButton = ({ handleOnClick }: Props) => {
       {/*buttonタグ + 小杉丸ゴシックフォントの組み合わせだと、スマホでのみ、１文字目（「覚」）が他の文字より明るくなるというバグに遭遇したため、divにしてある*/}
       <div
         onClick={handleOnClick}
-        className="h-12 w-28 cursor-pointer rounded bg-gray-300 sm:hover:bg-gray-500 active:bg-gray-500 flex items-center justify-center font-kosugi-maru rounded-lg text-lg font-bold"
+        className="relative flex items-center justify-center font-kosugi-maru rounded-full py-2.5 px-16 border-4 border-white shadow-lg shadow-black/25 sm:hover:border-gray-200 sm:hover:text-gray-200 active:border-gray-200 active:text-gray-200 bg-gradient-to-b from-navy-darkest to-navy-darker text-lg font-bold cursor-pointer"
       >
+        <span className="absolute top-1.5 w-42 h-5.5 bg-white opacity-30 rounded-full" />
         覚え直す
       </div>
     </>

--- a/src/components/stages/StartAnsweringButton.tsx
+++ b/src/components/stages/StartAnsweringButton.tsx
@@ -8,8 +8,9 @@ const StartAnsweringButton = ({ handleOnClick }: Props) => {
       {/*buttonタグ + 小杉丸ゴシックフォントの組み合わせだと、スマホでのみ、１文字目（「覚」）が他の文字より明るくなるというバグに遭遇したため、divにしてある*/}
       <div
         onClick={handleOnClick}
-        className="flex items-center justify-center font-kosugi-maru rounded-lg h-14 w-28 border-2 border-white sm:hover:border-gray-200 sm:hover:text-gray-200 active:border-gray-200 active:text-gray-200 bg-ok text-lg font-bold cursor-pointer animate-pulse animate-delay-[1800ms] animate-infinite"
+        className="relative flex items-center justify-center font-kosugi-maru rounded-full py-2.5 px-16 border-4 border-white shadow-lg shadow-black/25 sm:hover:border-gray-200 sm:hover:text-gray-200 active:border-gray-200 active:text-gray-200 bg-gradient-to-b from-navy-darker to-navy-lightest text-lg font-bold cursor-pointer animate-pulse animate-delay-[1800ms] animate-infinite"
       >
+        <span className="absolute top-1.5 w-42 h-5.5 bg-white opacity-30 rounded-full" />
         覚えた！
       </div>
     </>

--- a/src/pages/thank-you-for-playing.tsx
+++ b/src/pages/thank-you-for-playing.tsx
@@ -119,22 +119,20 @@ const ThankYouForPlaying = ({
       />
 
       <div className="flex flex-col items-center font-kosugi-maru pb-8">
-        <div className="text-black mt-6 mx-4 bg-white rounded-2xl px-6 py-5 relative before:absolute before:-bottom-5 before:mx-auto before:w-0 before:h-0 before:border-transparent before:left-0 before:right-0 before:border-10 before:border-t-10 before:border-t-white">
-          <h1 className="flex justify-center text-base mb-5 font-bold">
-            🎉{' '}
-            <span className="border-b-4 border-ok py-1">
-              全ステージクリア おめでとう！
-            </span>{' '}
-            🎉
+        <div className="text-black mt-6 mx-4 bg-white rounded-2xl py-5 relative before:absolute before:-bottom-5 before:mx-auto before:w-0 before:h-0 before:border-transparent before:left-0 before:right-0 before:border-10 before:border-t-10 before:border-t-white">
+          <h1 className="flex justify-center items-center text-base mb-5 font-bold py-1">
+            <span className="border-b-4 border-navy-lightest ">
+              🎉 全ステージクリア おめでとう！ 🎉
+            </span>
           </h1>
-          <div className="text-base px-1">{messageBody}</div>
+          <div className="text-base px-5">{messageBody}</div>
         </div>
-        <div className="pointer-events-none mt-6 mb-3 mr-9">
+        <div className="pointer-events-none mt-4 mb-3 mr-9">
           <Image
             src="/pandas/panda_happy_1.png"
             objectFit="contain"
-            width={320}
-            height={226}
+            width={220}
+            height={150}
             alt="happy panda"
             onContextMenu={(e: React.MouseEvent<HTMLImageElement>) =>
               e.preventDefault()
@@ -144,14 +142,22 @@ const ThankYouForPlaying = ({
             }
           />
         </div>
-        <div className="flex gap-x-4">
-          <FacebookButton text={shareButtonText} size={shareButtonSize} />
-          <TwitterButton text={shareButtonText} size={shareButtonSize} />
-          <Link href="/">
-            <a className="font-bold text-white w-28 py-3 cursor-pointer rounded bg-ok text-center">
-              もっと遊ぶ
-            </a>
-          </Link>
+        <Link href="/">
+          <a className="text-white relative flex items-center justify-center font-kosugi-maru rounded-full py-2.5 px-16 border-4 border-white shadow-lg shadow-black/25 sm:hover:border-gray-200 sm:hover:text-gray-200 active:border-gray-200 active:text-gray-200 bg-gradient-to-b from-navy-darker to-navy-lightest text-lg font-bold cursor-pointer mt-2">
+            <span className="absolute top-1.5 w-48 h-5.5 bg-white opacity-30 rounded-full" />
+            もっと遊ぶ
+          </a>
+        </Link>
+        <div className="flex flex-col items-center">
+          <div className="flex flex-col text-gray-500 mt-10">
+            <p>全ステージクリア、おめでとう！</p>
+            <p>今の気持ちとスペシャル画像を</p>
+            <p>友達とシェアしよう！</p>
+          </div>
+          <div className="flex gap-x-6 mt-2">
+            <FacebookButton text={shareButtonText} size={shareButtonSize} />
+            <TwitterButton text={shareButtonText} size={shareButtonSize} />
+          </div>
         </div>
       </div>
     </>

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -47,8 +47,13 @@ module.exports = withAnimations({
         locked: '#b7d6e8',
         mistaken: '#ffb5f0',
         ribbon: '#135acb',
-        ok: '#46d2aa',
         ng: '#ff3978',
+        'navy-darkest': '#47b4c6',
+        'navy-darker': '#43c3d4',
+        'navy-lighter': '#25cfdf',
+        'navy-lightest': '#2fdeee',
+        'ok-dark': '#04bc88',
+        'ok-light': '#59e7bf',
       },
       fontFamily: {
         'kosugi-maru': ['Kosugi Maru'],
@@ -56,6 +61,10 @@ module.exports = withAnimations({
       },
       width: {
         38: '152px',
+        42: '168px',
+      },
+      height: {
+        5.5: '22px',
       },
     },
   },


### PR DESCRIPTION
closes #195

## Before
<img width="350" alt="スクリーンショット 2022-03-16 17 55 15" src="https://user-images.githubusercontent.com/46347198/158554027-454e1999-b0b3-4b69-b6db-cd25a65a5d81.png">

<img width="350" alt="スクリーンショット 2022-03-16 17 55 53" src="https://user-images.githubusercontent.com/46347198/158553990-88cb9a5e-9098-4e7a-8204-1050c598c71b.png">

<img width="350" alt="スクリーンショット 2022-03-16 17 56 33" src="https://user-images.githubusercontent.com/46347198/158553926-adf1d9bd-7550-405b-952a-537cceb51e77.png">

## After
<img width="350" alt="スクリーンショット 2022-03-16 17 55 25" src="https://user-images.githubusercontent.com/46347198/158554048-c5c28ecb-a17f-4202-88b2-de45b0b58958.png">

<img width="350" alt="スクリーンショット 2022-03-16 17 55 43" src="https://user-images.githubusercontent.com/46347198/158553999-4e58fad4-ddb9-4e8f-8b91-6374659f5e77.png">

<img width="350" alt="スクリーンショット 2022-03-16 17 57 10" src="https://user-images.githubusercontent.com/46347198/158553889-a9f37f85-9c9d-469e-931c-f1e04e6a9f92.png">

## 備考
- SNS シェアボタン付近に説明用の文言を加えた
- ステージ画面先頭のリボンがモーダルより全面に出てきてしまっているのを修正した

---

PR提出前のチェックリスト：
- [x] 関連するコミットをsquashした
